### PR TITLE
removing ssh keyname field and open inbound ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,20 @@ The Cloud Formation script should create the following:
 
 1. Navigate to **./client** and run `npm install`.
 2. Edit **./demo/index.html** to add the API Gateway endpoint and API key that are output by the Cloud Formation script (step 6 above).
-3. Build the component using WebPack `./node_modules/.bin/webpack --config webpack.config.js`
-4. Server the demo webpage on localhost `./node_modules/.bin/webpack-dev-server --open`
+3. Build the component using WebPack 
+
+        ./node_modules/.bin/webpack --config webpack.config.js 
+    or
+     
+        npm build
+4. Serve the demo webpage on localhost 
+    
+        ./node_modules/.bin/webpack-dev-server --open
+      
+             
+     or
+             
+        npm start
 
 The browser should open automatically at index.html. The page contains 2 embedded snapshot graphs displaying the CPUUtilization and CPUCreditUsage metrics your EC2. 
 

--- a/server/apigateway-lambda.json
+++ b/server/apigateway-lambda.json
@@ -2,12 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Description": "AWS CloudFormation sample template that contains a single Lambda function behind an API Gateway",
 
-  "Parameters" : {
-    "KeyName": {
-      "Description" : "Name of an existing EC2 KeyPair to enable SSH access to the instance",
-      "Type": "AWS::EC2::KeyPair::KeyName",
-      "ConstraintDescription" : "Can contain only ASCII characters."
-    },  
+  "Parameters" : { 
     "InstanceType" : {
       "Description" : "WebServer EC2 instance type",
       "Type" : "String",
@@ -251,8 +246,6 @@
         "VpcId" : { "Ref" : "VPC" },
         "GroupDescription" : "Enable SSH access via port 22",
         "SecurityGroupIngress" : [
-          {"IpProtocol" : "tcp", "FromPort" : "22", "ToPort" : "22", "CidrIp" : "0.0.0.0/0"},
-          { "IpProtocol" : "tcp", "FromPort" : "80", "ToPort" : "80", "CidrIp" : "0.0.0.0/0"}
          ]
       }
     },
@@ -263,7 +256,6 @@
         "ImageId" : { "Fn::FindInMap" : [ "AWSRegionArch2AMI", { "Ref" : "AWS::Region" },
                           { "Fn::FindInMap" : [ "AWSInstanceType2Arch", { "Ref" : "InstanceType" }, "Arch" ] } ] },
         "InstanceType"   : { "Ref" : "InstanceType" },
-        "KeyName"        : { "Ref" : "KeyName" },
         "Monitoring"     : "true",
         "NetworkInterfaces" : [{
           "GroupSet"                 : [{ "Ref" : "InstanceSecurityGroup" }],


### PR DESCRIPTION
the ssh key name and the open inbound parts are insecure (this functionality provably works without them).

*Issue #4 *

*Description of changes:*
Disabled inbound ports 22 and 80, and the KeyName for just a basic outside aws console dashboard.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
