### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/server/apigateway-lambda.json
+++ b/server/apigateway-lambda.json
@@ -279,7 +279,7 @@
         "FunctionName": "SnapshotGraphsLambda",
         "Handler": "server.myHandler",
         "Role": { "Fn::GetAtt": ["LambdaExecutionRole", "Arn"]},
-        "Runtime": "nodejs8.10"
+        "Runtime": "nodejs10.x"
       }
     },
 


### PR DESCRIPTION
CloudFormation templates in aws-cloudwatch-building-dashboard-outside-aws-console have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.