### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/server/apigateway-lambda.json
+++ b/server/apigateway-lambda.json
@@ -279,7 +279,7 @@
         "FunctionName": "SnapshotGraphsLambda",
         "Handler": "server.myHandler",
         "Role": { "Fn::GetAtt": ["LambdaExecutionRole", "Arn"]},
-        "Runtime": "nodejs10.x"
+        "Runtime": "nodejs14.x"
       }
     },
 


### PR DESCRIPTION
CloudFormation templates in aws-cloudwatch-building-dashboard-outside-aws-console have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.